### PR TITLE
Bump version string to 1.0.0

### DIFF
--- a/caplena/version.py
+++ b/caplena/version.py
@@ -1,3 +1,3 @@
-__version__ = "0.0.3"
+__version__ = "1.0.0"
 
 # note: implements OpenAPI specification: 92eadda6c1155ac099a06d598af8135f68673c37


### PR DESCRIPTION
Bump version string in `caplena/version.py` to 1.0.0, so that `caplena.__version__` reflects the correct version.