### PR TITLE
(fix) handle windows returning requests.encoding='UTF-8' instead of l…

### DIFF
--- a/caplena/http/requests_http_client.py
+++ b/caplena/http/requests_http_client.py
@@ -42,7 +42,7 @@ class RequestsHttpClient(HttpClient):
             response.raise_for_status()
 
         # note: we only support utf-8 encodings
-        if response.encoding != "utf-8":
+        if response.encoding.lower() != "utf-8":
             raise ValueError(
                 f"Received a response with an unsupported encoding scheme (encoding='{response.encoding}')."
             )

--- a/caplena/http/requests_http_client.py
+++ b/caplena/http/requests_http_client.py
@@ -42,7 +42,7 @@ class RequestsHttpClient(HttpClient):
             response.raise_for_status()
 
         # note: we only support utf-8 encodings
-        if response.encoding.lower() != "utf-8":
+        if response.encoding is None or response.encoding.lower() != "utf-8":
             raise ValueError(
                 f"Received a response with an unsupported encoding scheme (encoding='{response.encoding}')."
             )


### PR DESCRIPTION
…owercase 'utf-8' as on darwin and linux

customers are using windows and sometimes for some reason get response.encoding="UTF-8"