### PR TITLE
feat: add row id results to bulk row append operation

### DIFF
--- a/caplena/endpoints/projects_endpoint.py
+++ b/caplena/endpoints/projects_endpoint.py
@@ -649,7 +649,13 @@ class ListedProject(BaseResource[ProjectsController]):
 class RowsAppend(BaseObject[ProjectsController]):
     """The bulk row create response object."""
 
-    __fields__ = {"status", "queued_rows_count", "estimated_minutes"}
+    class RowsAppendResult(BaseObject[ProjectsController]):
+        __fields__ = {"id"}
+
+        id: str
+        """The identifier of the row that was appended."""
+
+    __fields__ = {"status", "queued_rows_count", "estimated_minutes", "results"}
 
     status: Literal["pending"]
     """Status of the bulk append operation."""
@@ -658,7 +664,17 @@ class RowsAppend(BaseObject[ProjectsController]):
     """Number of rows that were queued for appending."""
 
     estimated_minutes: float
-    """Estimation in minutes about how long this bulk opertion will approximately take."""
+    """Estimation in minutes about how long this bulk operation will approximately take."""
+
+    results: CaplenaList[RowsAppendResult]
+    """The results of the bulk append operation."""
+
+    @classmethod
+    def parse_obj(cls, obj: Dict[str, Any]) -> "RowsAppend":
+        obj["results"] = CaplenaList(
+            values=[cls.RowsAppendResult.parse_obj(res) for res in obj["results"]]
+        )
+        return super().parse_obj(obj)
 
 
 class Row(BaseResource[ProjectsController]):

--- a/tests/controllers/test_projects_controller.py
+++ b/tests/controllers/test_projects_controller.py
@@ -260,11 +260,13 @@ class ProjectsControllerTests(unittest.TestCase):
 
     def test_appending_multiple_rows_succeeds(self) -> None:
         project = self.create_project()
-        result = self.controller.append_rows(id=project.id, rows=project_rows_create_payload())
+        response = self.controller.append_rows(id=project.id, rows=project_rows_create_payload())
 
-        self.assertEqual("pending", result.status)
-        self.assertEqual(2, result.queued_rows_count)
-        self.assertEqual(1.02, result.estimated_minutes)
+        self.assertEqual("pending", response.status)
+        self.assertEqual(2, response.queued_rows_count)
+        self.assertEqual(1.02, response.estimated_minutes)
+        self.assertEqual(2, len(response.results))
+        self.assertTrue(all([isinstance(row.id, str) for row in response.results]))
 
     def test_appending_single_row_succeeds(self) -> None:
         project = self.create_project()


### PR DESCRIPTION
Updates the client library to make the returned row ids usable from bulk row append.