### PR TITLE
feat: support inverted filters via ~ operator

### DIFF
--- a/caplena/api/api_filter.py
+++ b/caplena/api/api_filter.py
@@ -48,11 +48,17 @@ class ApiFilter:
             query_params[query_param] = ";".join(stringified_clauses)
         return query_params
 
+    def _mark_inverted_clauses(self, constraints: Constraints) -> None:
+        for clauses in constraints.values():
+            for clause in clauses:
+                clause[INVERTED_CLAUSE_KEY] = True
+
     def __str__(self) -> str:
         stringified_clauses: List[str] = []
         for name, clauses in self._constraints.items():
             for clause in clauses:
                 stringified_literals: List[str] = []
+                is_inverted = clause.get(INVERTED_CLAUSE_KEY, self._is_inverted)
                 for modifier, values in clause.items():
                     if modifier == INVERTED_CLAUSE_KEY:
                         continue
@@ -60,7 +66,8 @@ class ApiFilter:
                     if modifier != self.DEFAULT:
                         filt_name += f".{modifier}"
                     str_values = ",".join([str(value) for value in values])
-                    stringified_literals.append(f"{filt_name}={{{str_values}}}")
+                    equals = "!" if is_inverted else "="
+                    stringified_literals.append(f"{filt_name}{equals}{{{str_values}}}")
                 stringified_clauses.append("(" + " | ".join(stringified_literals) + ")")
         return "ApiFilter(" + " & ".join(stringified_clauses) + ")"
 
@@ -85,6 +92,9 @@ class ApiFilter:
         new_constraints = copy.deepcopy(self._constraints)
         other_constraints = copy.deepcopy(other._constraints)
 
+        if self._is_inverted:
+            self._mark_inverted_clauses(new_constraints)
+
         has_conjunction = len(new_constraints.keys()) > 0 and len(other_constraints.keys()) > 0
         has_conjunction = self._has_conjunction if self._has_conjunction else has_conjunction
         has_conjunction = other._has_conjunction if other._has_conjunction else has_conjunction
@@ -104,7 +114,7 @@ class ApiFilter:
         return type(self)(
             constraints=new_constraints,
             has_conjunction=has_conjunction,
-            is_inverted=self._is_inverted,
+            is_inverted=False,
         )
 
     def __or__(self: U, other: U) -> U:

--- a/caplena/api/api_filter.py
+++ b/caplena/api/api_filter.py
@@ -9,6 +9,7 @@ U = TypeVar("U", bound="ApiFilter")
 
 ZeroOrMany = Optional[Union[T, List[T]]]
 Constraints = Dict[str, List[Dict[str, List[Any]]]]
+INVERTED_CLAUSE_KEY = "__inverted__"
 
 
 class ApiFilter:
@@ -18,10 +19,12 @@ class ApiFilter:
         self,
         constraints: Optional[Constraints] = None,
         has_conjunction: bool = False,
+        is_inverted: bool = False,
     ):
         # TODO: how to restrict AND, OR, NONE operations
         self._constraints: Constraints = constraints if constraints is not None else {}
         self._has_conjunction = has_conjunction
+        self._is_inverted = is_inverted
 
     def to_query_params(self) -> Dict[str, str]:
         query_params: Dict[str, str] = {}
@@ -29,11 +32,17 @@ class ApiFilter:
             stringified_clauses: List[str] = []
             for clause in clauses:
                 stringified_literals: List[str] = []
+                is_inverted = clause.get(INVERTED_CLAUSE_KEY, self._is_inverted)
                 for modifier, values in clause.items():
+                    if modifier == INVERTED_CLAUSE_KEY:
+                        continue
                     for value in values:
                         str_value = Helpers.build_escaped_filter_str(self.to_string(value=value))
+                        equals = "!" if is_inverted else ":"
                         if modifier != self.DEFAULT:
-                            str_value = f"{modifier}:" + str_value
+                            str_value = f"{modifier}{equals}{str_value}"
+                        elif is_inverted:
+                            str_value = f"!{str_value}"
                         stringified_literals.append(str_value)
                 stringified_clauses.append(",".join(stringified_literals))
             query_params[query_param] = ";".join(stringified_clauses)
@@ -45,6 +54,8 @@ class ApiFilter:
             for clause in clauses:
                 stringified_literals: List[str] = []
                 for modifier, values in clause.items():
+                    if modifier == INVERTED_CLAUSE_KEY:
+                        continue
                     filt_name = f"{name}"
                     if modifier != self.DEFAULT:
                         filt_name += f".{modifier}"
@@ -52,6 +63,14 @@ class ApiFilter:
                     stringified_literals.append(f"{filt_name}={{{str_values}}}")
                 stringified_clauses.append("(" + " | ".join(stringified_literals) + ")")
         return "ApiFilter(" + " & ".join(stringified_clauses) + ")"
+
+    def __invert__(self: U) -> U:
+        """Return a filter that matches resources not satisfying this filter."""
+        return type(self)(
+            constraints=copy.deepcopy(self._constraints),
+            has_conjunction=self._has_conjunction,
+            is_inverted=not self._is_inverted,
+        )
 
     def __and__(self: U, other: U) -> U:
         """Creates and returns the immutable conjunction of two separate filters. The original
@@ -71,12 +90,22 @@ class ApiFilter:
         has_conjunction = other._has_conjunction if other._has_conjunction else has_conjunction
 
         for name, clauses in other_constraints.items():
+            clauses_to_add = []
+            for clause in clauses:
+                clause_copy = copy.deepcopy(clause)
+                if other._is_inverted:
+                    clause_copy[INVERTED_CLAUSE_KEY] = True
+                clauses_to_add.append(clause_copy)
             if name in new_constraints:
-                new_constraints[name].extend(clauses)
+                new_constraints[name].extend(clauses_to_add)
             else:
-                new_constraints[name] = clauses
+                new_constraints[name] = clauses_to_add
 
-        return type(self)(constraints=new_constraints, has_conjunction=has_conjunction)
+        return type(self)(
+            constraints=new_constraints,
+            has_conjunction=has_conjunction,
+            is_inverted=self._is_inverted,
+        )
 
     def __or__(self: U, other: U) -> U:
         """Creates and returns the immutable disjunction of two separate filters. The original
@@ -88,17 +117,26 @@ class ApiFilter:
         :type other: Filter
         :rtype: Filter
         """
+        if self._is_inverted != other._is_inverted:
+            raise ValueError(
+                "Cannot combine inverted and non-inverted filters with OR. "
+                "Use AND (&) instead, or invert the entire expression."
+            )
+
         new_constraints = copy.deepcopy(self._constraints)
         other_constraints = copy.deepcopy(other._constraints)
         new_filters = list(new_constraints.keys())
         other_filters = list(other_constraints.keys())
 
+        is_inverted = self._is_inverted
+
         has_conjunction = False
         if len(new_filters) == 0:
             has_conjunction = other._has_conjunction
             new_constraints = other_constraints
+            is_inverted = other._is_inverted
         elif len(other_filters) == 0:
-            has_conjunction = other._has_conjunction
+            has_conjunction = self._has_conjunction
         elif self._has_conjunction or other._has_conjunction:
             raise ValueError(
                 "Cannot build the disjunction of already conjuncted filters To fix this error, please make sure "
@@ -119,10 +157,18 @@ class ApiFilter:
             elif len(new_filters) == 1 and len(other_filters) == 1:
                 name = new_filters[0]
                 for filt_name, values in other_constraints[name][0].items():
+                    if filt_name == INVERTED_CLAUSE_KEY:
+                        continue
                     new_constraints[name][0].setdefault(filt_name, [])
                     new_constraints[name][0][filt_name].extend(values)
+                if is_inverted:
+                    new_constraints[name][0][INVERTED_CLAUSE_KEY] = True
 
-        return type(self)(constraints=new_constraints, has_conjunction=has_conjunction)
+        return type(self)(
+            constraints=new_constraints,
+            has_conjunction=has_conjunction,
+            is_inverted=is_inverted,
+        )
 
     @classmethod
     def construct(cls: Type[U], *, name: str, filters: Dict[str, ZeroOrMany[Any]]) -> U:

--- a/caplena/api/api_filter.py
+++ b/caplena/api/api_filter.py
@@ -8,7 +8,8 @@ T = TypeVar("T")
 U = TypeVar("U", bound="ApiFilter")
 
 ZeroOrMany = Optional[Union[T, List[T]]]
-Constraints = Dict[str, List[Dict[str, List[Any]]]]
+FilterClause = Dict[str, Union[List[Any], bool]]
+Constraints = Dict[str, List[FilterClause]]
 INVERTED_CLAUSE_KEY = "__inverted__"
 
 
@@ -34,7 +35,7 @@ class ApiFilter:
                 stringified_literals: List[str] = []
                 is_inverted = clause.get(INVERTED_CLAUSE_KEY, self._is_inverted)
                 for modifier, values in clause.items():
-                    if modifier == INVERTED_CLAUSE_KEY:
+                    if modifier == INVERTED_CLAUSE_KEY or not isinstance(values, list):
                         continue
                     for value in values:
                         str_value = Helpers.build_escaped_filter_str(self.to_string(value=value))
@@ -60,7 +61,7 @@ class ApiFilter:
                 stringified_literals: List[str] = []
                 is_inverted = clause.get(INVERTED_CLAUSE_KEY, self._is_inverted)
                 for modifier, values in clause.items():
-                    if modifier == INVERTED_CLAUSE_KEY:
+                    if modifier == INVERTED_CLAUSE_KEY or not isinstance(values, list):
                         continue
                     filt_name = f"{name}"
                     if modifier != self.DEFAULT:
@@ -167,10 +168,14 @@ class ApiFilter:
             elif len(new_filters) == 1 and len(other_filters) == 1:
                 name = new_filters[0]
                 for filt_name, values in other_constraints[name][0].items():
-                    if filt_name == INVERTED_CLAUSE_KEY:
+                    if filt_name == INVERTED_CLAUSE_KEY or not isinstance(values, list):
                         continue
-                    new_constraints[name][0].setdefault(filt_name, [])
-                    new_constraints[name][0][filt_name].extend(values)
+                    clause_dict = new_constraints[name][0]
+                    current = clause_dict.get(filt_name)
+                    if not isinstance(current, list):
+                        current = []
+                        clause_dict[filt_name] = current
+                    current.extend(values)
                 if is_inverted:
                     new_constraints[name][0][INVERTED_CLAUSE_KEY] = True
 
@@ -184,11 +189,11 @@ class ApiFilter:
     def construct(cls: Type[U], *, name: str, filters: Dict[str, ZeroOrMany[Any]]) -> U:
         constraints: Constraints = {}
 
-        clauses: List[Dict[str, List[Any]]] = []
+        clauses: List[FilterClause] = []
         for filter_name, values in filters.items():
             values_list = cls.to_list(values=values)
             if values_list is not None:
-                clause: Dict[str, List[Any]] = {}
+                clause: FilterClause = {}
                 clause[filter_name] = values_list
                 clauses.append(clause)
 

--- a/caplena/helpers.py
+++ b/caplena/helpers.py
@@ -80,7 +80,7 @@ class Helpers:
     @staticmethod
     def build_escaped_filter_str(value: str) -> str:
         escaped = value.replace("\\", "\\\\")
-        return re.sub(r"(:|,|;)", r"\\\1", escaped)
+        return re.sub(r"(:|,|;|!)", r"\\\1", escaped)
 
     @staticmethod
     def build_dict(**kwargs: Any) -> Dict[str, Any]:

--- a/docs/source/retrieving-results.rst
+++ b/docs/source/retrieving-results.rst
@@ -77,7 +77,7 @@ Projects last modified after given date matching a tag
   client.projects.list(filter=P.last_modified(gte="2022-01-01T00:00:00") & P.tags("NPS"))
 
 Inverted filters
----------------
+----------------
 
 Individual filter constraints can be **inverted** so that matching resources are those
 that do **not** satisfy the constraint. Prefix a filter expression with :code:`~`:

--- a/docs/source/retrieving-results.rst
+++ b/docs/source/retrieving-results.rst
@@ -76,6 +76,36 @@ Projects last modified after given date matching a tag
 
   client.projects.list(filter=P.last_modified(gte="2022-01-01T00:00:00") & P.tags("NPS"))
 
+Inverted filters
+---------------
+
+Individual filter constraints can be **inverted** so that matching resources are those
+that do **not** satisfy the constraint. Prefix a filter expression with :code:`~`:
+
+.. code-block:: python
+
+  # Projects that are NOT tagged with "archived"
+  projects = client.projects.list(filter=~P.tags("archived"))
+
+  # Projects whose name does NOT contain "draft"
+  projects = client.projects.list(filter=~P.name(contains__i="draft"))
+
+Inverted filters combine with :code:`&` and :code:`|` like any other filter.
+
+Under the hood, the client encodes an inverted constraint with :code:`!` instead of
+:code:`:` as the separator between modifier and value (for example, :code:`tags=!archived`).
+See `Filtering <https://caplena.com/docs/developers/c4e34366a7243-filtering#inverted-filters>`_
+in the API documentation for the full query-string syntax.
+
+Filter value escaping
+---------------------
+
+When serializing :code:`ProjectsFilter` and :code:`RowsFilter` to query parameters, the
+client escapes special characters in filter values so they are not interpreted as syntax:
+backslash (:code:`\\`), comma (:code:`,`), semicolon (:code:`;`), colon (:code:`:`), and
+exclamation mark (:code:`!`). You do not need to escape these manually when using the
+filter helpers.
+
 
 Retrieving topics
 ---------------

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -343,3 +343,26 @@ class ApiFilterQueryParamTests(unittest.TestCase):
         }
 
         self.assertEqual(expected, filt.to_query_params())
+
+    def test_inverted_filter_succeeds(self) -> None:
+        self.assertEqual({"tags": "!archived"}, (~Pf.tags("archived")).to_query_params())
+        self.assertEqual(
+            {"tags": "active;!archived"},
+            (Pf.tags("active") & ~Pf.tags("archived")).to_query_params(),
+        )
+        self.assertEqual(
+            {"created": "year!2020"},
+            (~Pf.created(year=2020)).to_query_params(),
+        )
+        self.assertEqual(
+            {"tags": "!a,!b"},
+            (~Pf.tags("a") | ~Pf.tags("b")).to_query_params(),
+        )
+        self.assertEqual(
+            Pf.tags("archived").to_query_params(),
+            (~(~Pf.tags("archived"))).to_query_params(),
+        )
+
+    def test_inverted_or_filter_fails(self) -> None:
+        with self.assertRaisesRegex(ValueError, "inverted and non-inverted filters with OR"):
+            ~Pf.tags("a") | Pf.tags("b")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -351,6 +351,14 @@ class ApiFilterQueryParamTests(unittest.TestCase):
             (Pf.tags("active") & ~Pf.tags("archived")).to_query_params(),
         )
         self.assertEqual(
+            {"tags": "!a;b"},
+            (~Pf.tags("a") & Pf.tags("b")).to_query_params(),
+        )
+        self.assertEqual(
+            {"tags": "!a", "created": "year:2020"},
+            (~Pf.tags("a") & Pf.created(year=2020)).to_query_params(),
+        )
+        self.assertEqual(
             {"created": "year!2020"},
             (~Pf.created(year=2020)).to_query_params(),
         )

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -74,11 +74,13 @@ class HelperTests(unittest.TestCase):
             "abc cdef \\ \n ghj xyz",
             "th:is;is;just,a,ve:ry;lo:ng;tag",
             "just\\some\\\nmany\\\\\\backslashes\\n",
+            "not!inverted",
         ]
         escaped = [
             "abc cdef \\\\ \n ghj xyz",
             "th\\:is\\;is\\;just\\,a\\,ve\\:ry\\;lo\\:ng\\;tag",
             "just\\\\some\\\\\nmany\\\\\\\\\\\\backslashes\\\\n",
+            "not\\!inverted",
         ]
 
         self.assertListEqual(escaped, [Helpers.build_escaped_filter_str(un) for un in unescaped])


### PR DESCRIPTION
## Summary
- Add `__invert__()` on `ApiFilter` so filters can be negated with `~` (e.g. `~P.tags("archived")`)
- Serialize inverted constraints using `!` instead of `:` to match the REST API (labelhippoapi #4194)
- Escape `!` in filter values alongside existing special characters
- Document inverted filters and escaping in the Python SDK docs

## Test plan
- [x] `pytest tests/test_api.py::ApiFilterQueryParamTests`
- [x] `pytest tests/test_helpers.py::HelperTests::test_escaping_filter_string_succeeds`
- [ ] After merge: bump version and rebuild hosted SDK docs in `docs-external-site`


Made with [Cursor](https://cursor.com)